### PR TITLE
Update calculateLabel.ts

### DIFF
--- a/src/calculateLabel.ts
+++ b/src/calculateLabel.ts
@@ -32,7 +32,7 @@ export function calculateTotalFloodLabel(score: number) {
    */ 
 
 
-  if (score >= 0 && score <= 16) {
+  if (score <= 16) {
     return "a";
   }
 


### PR DESCRIPTION
- Disable `>= 0` check which could result in a false label E (reported by Jelle)